### PR TITLE
Add road_damage data

### DIFF
--- a/road_damage.zip
+++ b/road_damage.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:639b3aec3f067a79b02dd12cae4bdd7235c886988c7e733ee3554a8fc74bc069
+size 108389512


### PR DESCRIPTION
Add the `road_damage.zip` file, with all the images from Japan at the [Global Road Damage Detection Challenge 2020](https://rdd2020.sekilab.global/data/) 